### PR TITLE
fix: commit keys even if write conflict occurs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,7 @@ mod tests {
 
             let mut t0 = db.new_txn();
             let mut t1 = db.new_txn();
+            let mut t2 = db.new_txn();
 
             t0.set(
                 "key0".into(),
@@ -388,11 +389,20 @@ mod tests {
                 "key0".into(),
                 t1.get(&"key0".to_owned(), |v| *v).await.unwrap(),
             );
+            t1.set(
+                "key2".into(),
+                2
+            );
+            t2.set(
+                "key2".into(),
+                3
+            );
 
             t0.commit().await.unwrap();
 
             let commit = t1.commit().await;
             assert!(commit.is_err());
+            assert!(t2.commit().await.is_ok());
             if let Err(CommitError::WriteConflict(keys)) = commit {
                 assert_eq!(db.new_txn().get(&keys[0], |v| *v).await, Some(1));
                 return;

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -74,12 +74,11 @@ where
                     panic!("middle record should in a batch");
                 }
                 RecordType::Last => {
-                    if let Some(b) = &mut batch {
-                        b.push(record);
-                        let batch = batch.take().unwrap();
-                        for record in batch {
-                            self.insert(record.key, record.ts, record.value);
+                    if let Some(b) = batch.take() {
+                        for r in b {
+                            self.insert(r.key, r.ts, r.value);
                         }
+                        self.insert(record.key, record.ts, record.value);
                         continue;
                     }
                     panic!("last record should in a batch");

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -117,11 +117,9 @@ where
             .collect();
 
         if !conflicts.is_empty() {
-            committed_txns.insert(write_at, in_write);
-            Err(WriteConflict { keys: conflicts })
-        } else {
-            committed_txns.insert(write_at, in_write);
-            Ok(())
+            return Err(WriteConflict { keys: conflicts });
         }
+        committed_txns.insert(write_at, in_write);
+        Ok(())
     }
 }


### PR DESCRIPTION
when a write conflict occurs, keys are still committed, causing write conflicts to occur in other transaction chains.
